### PR TITLE
feat: add claude configuration support to dotfiles push/pull

### DIFF
--- a/commands/dotfiles_pull.go
+++ b/commands/dotfiles_pull.go
@@ -64,6 +64,7 @@ func pullDotfiles(c *cli.Context) error {
 		"zsh":     model.NewZshApp(),
 		"bash":    model.NewBashApp(),
 		"ghostty": model.NewGhosttyApp(),
+		"claude":  model.NewClaudeApp(),
 	}
 
 	// Process fetched dotfiles
@@ -138,7 +139,7 @@ func pullDotfiles(c *cli.Context) error {
 		// Filter out files that are already equal
 		filesToUpdate := make(map[string]string)
 		var pathsToActuallyBackup []string
-		
+
 		for path, content := range filesToProcess {
 			if isEqual, exists := equalityMap[path]; exists && isEqual {
 				logrus.Debugf("Skipping %s - content is identical", path)

--- a/commands/dotfiles_push.go
+++ b/commands/dotfiles_push.go
@@ -42,6 +42,7 @@ func pushDotfiles(c *cli.Context) error {
 		model.NewZshApp(),
 		model.NewBashApp(),
 		model.NewGhosttyApp(),
+		model.NewClaudeApp(),
 	}
 
 	// Filter apps based on user input

--- a/model/dotfile_claude.go
+++ b/model/dotfile_claude.go
@@ -1,0 +1,31 @@
+package model
+
+import "context"
+
+// ClaudeApp handles Claude Code configuration files
+type ClaudeApp struct {
+	BaseApp
+}
+
+func NewClaudeApp() DotfileApp {
+	return &ClaudeApp{}
+}
+
+func (c *ClaudeApp) Name() string {
+	return "claude"
+}
+
+func (c *ClaudeApp) GetConfigPaths() []string {
+	return []string{
+		"~/.claude/settings.json",
+		"~/.config/claude/settings.json",
+		"~/.claude/config.json",
+		"~/.config/claude/config.json",
+		".claude/settings.json",
+		"CLAUDE.md",
+	}
+}
+
+func (c *ClaudeApp) CollectDotfiles(ctx context.Context) ([]DotfileItem, error) {
+	return c.CollectFromPaths(ctx, c.Name(), c.GetConfigPaths())
+}


### PR DESCRIPTION
Add support for Claude Code configuration in dotfiles push and pull commands.

## Changes
- Added ClaudeApp implementation in model/dotfile_claude.go
- Support common Claude config paths (~/.claude/settings.json, .claude/, CLAUDE.md)
- Enable claude app in dotfiles push and pull commands
- Users can now sync Claude Code configuration using dotfiles functionality

Resolves #84

Generated with [Claude Code](https://claude.ai/code)