### PR TITLE
feat: add starship config support to dotfiles push/pull

### DIFF
--- a/commands/dotfiles_pull.go
+++ b/commands/dotfiles_pull.go
@@ -58,13 +58,14 @@ func pullDotfiles(c *cli.Context) error {
 
 	// Initialize all available app handlers
 	allApps := map[string]model.DotfileApp{
-		"nvim":    model.NewNvimApp(),
-		"fish":    model.NewFishApp(),
-		"git":     model.NewGitApp(),
-		"zsh":     model.NewZshApp(),
-		"bash":    model.NewBashApp(),
-		"ghostty": model.NewGhosttyApp(),
-		"claude":  model.NewClaudeApp(),
+		"nvim":     model.NewNvimApp(),
+		"fish":     model.NewFishApp(),
+		"git":      model.NewGitApp(),
+		"zsh":      model.NewZshApp(),
+		"bash":     model.NewBashApp(),
+		"ghostty":  model.NewGhosttyApp(),
+		"claude":   model.NewClaudeApp(),
+		"starship": model.NewStarshipApp(),
 	}
 
 	// Process fetched dotfiles

--- a/commands/dotfiles_push.go
+++ b/commands/dotfiles_push.go
@@ -43,6 +43,7 @@ func pushDotfiles(c *cli.Context) error {
 		model.NewBashApp(),
 		model.NewGhosttyApp(),
 		model.NewClaudeApp(),
+		model.NewStarshipApp(),
 	}
 
 	// Filter apps based on user input

--- a/model/dotfile_starship.go
+++ b/model/dotfile_starship.go
@@ -1,0 +1,26 @@
+package model
+
+import "context"
+
+// StarshipApp handles Starship configuration files
+type StarshipApp struct {
+	BaseApp
+}
+
+func NewStarshipApp() DotfileApp {
+	return &StarshipApp{}
+}
+
+func (s *StarshipApp) Name() string {
+	return "starship"
+}
+
+func (s *StarshipApp) GetConfigPaths() []string {
+	return []string{
+		"~/.config/starship.toml",
+	}
+}
+
+func (s *StarshipApp) CollectDotfiles(ctx context.Context) ([]DotfileItem, error) {
+	return s.CollectFromPaths(ctx, s.Name(), s.GetConfigPaths())
+}


### PR DESCRIPTION
Adds starship configuration support to the dotfiles push and pull commands.

## Changes
- Add StarshipApp implementation in model/dotfile_starship.go
- Update dotfiles_pull.go to include starship in available apps
- Update dotfiles_push.go to include starship in available apps
- Starship config file supported: ~/.config/starship.toml

Fixes #87

🤖 Generated with [Claude Code](https://claude.ai/code)