### PR TITLE
feat: add npm, ssh, kitty, and kubernetes dotfile support

### DIFF
--- a/commands/dotfiles_pull.go
+++ b/commands/dotfiles_pull.go
@@ -58,14 +58,18 @@ func pullDotfiles(c *cli.Context) error {
 
 	// Initialize all available app handlers
 	allApps := map[string]model.DotfileApp{
-		"nvim":     model.NewNvimApp(),
-		"fish":     model.NewFishApp(),
-		"git":      model.NewGitApp(),
-		"zsh":      model.NewZshApp(),
-		"bash":     model.NewBashApp(),
-		"ghostty":  model.NewGhosttyApp(),
-		"claude":   model.NewClaudeApp(),
-		"starship": model.NewStarshipApp(),
+		"nvim":       model.NewNvimApp(),
+		"fish":       model.NewFishApp(),
+		"git":        model.NewGitApp(),
+		"zsh":        model.NewZshApp(),
+		"bash":       model.NewBashApp(),
+		"ghostty":    model.NewGhosttyApp(),
+		"claude":     model.NewClaudeApp(),
+		"starship":   model.NewStarshipApp(),
+		"npm":        model.NewNpmApp(),
+		"ssh":        model.NewSshApp(),
+		"kitty":      model.NewKittyApp(),
+		"kubernetes": model.NewKubernetesApp(),
 	}
 
 	// Process fetched dotfiles

--- a/commands/dotfiles_push.go
+++ b/commands/dotfiles_push.go
@@ -44,6 +44,10 @@ func pushDotfiles(c *cli.Context) error {
 		model.NewGhosttyApp(),
 		model.NewClaudeApp(),
 		model.NewStarshipApp(),
+		model.NewNpmApp(),
+		model.NewSshApp(),
+		model.NewKittyApp(),
+		model.NewKubernetesApp(),
 	}
 
 	// Filter apps based on user input

--- a/model/dotfile_kitty.go
+++ b/model/dotfile_kitty.go
@@ -1,0 +1,26 @@
+package model
+
+import "context"
+
+// KittyApp handles Kitty terminal configuration files
+type KittyApp struct {
+	BaseApp
+}
+
+func NewKittyApp() DotfileApp {
+	return &KittyApp{}
+}
+
+func (k *KittyApp) Name() string {
+	return "kitty"
+}
+
+func (k *KittyApp) GetConfigPaths() []string {
+	return []string{
+		"~/.config/kitty/",
+	}
+}
+
+func (k *KittyApp) CollectDotfiles(ctx context.Context) ([]DotfileItem, error) {
+	return k.CollectFromPaths(ctx, k.Name(), k.GetConfigPaths())
+}

--- a/model/dotfile_kubernetes.go
+++ b/model/dotfile_kubernetes.go
@@ -1,0 +1,26 @@
+package model
+
+import "context"
+
+// KubernetesApp handles Kubernetes configuration files
+type KubernetesApp struct {
+	BaseApp
+}
+
+func NewKubernetesApp() DotfileApp {
+	return &KubernetesApp{}
+}
+
+func (k *KubernetesApp) Name() string {
+	return "kubernetes"
+}
+
+func (k *KubernetesApp) GetConfigPaths() []string {
+	return []string{
+		"~/.kube/config",
+	}
+}
+
+func (k *KubernetesApp) CollectDotfiles(ctx context.Context) ([]DotfileItem, error) {
+	return k.CollectFromPaths(ctx, k.Name(), k.GetConfigPaths())
+}

--- a/model/dotfile_npm.go
+++ b/model/dotfile_npm.go
@@ -1,0 +1,26 @@
+package model
+
+import "context"
+
+// NpmApp handles npm configuration files
+type NpmApp struct {
+	BaseApp
+}
+
+func NewNpmApp() DotfileApp {
+	return &NpmApp{}
+}
+
+func (n *NpmApp) Name() string {
+	return "npm"
+}
+
+func (n *NpmApp) GetConfigPaths() []string {
+	return []string{
+		"~/.npmrc",
+	}
+}
+
+func (n *NpmApp) CollectDotfiles(ctx context.Context) ([]DotfileItem, error) {
+	return n.CollectFromPaths(ctx, n.Name(), n.GetConfigPaths())
+}

--- a/model/dotfile_ssh.go
+++ b/model/dotfile_ssh.go
@@ -1,0 +1,26 @@
+package model
+
+import "context"
+
+// SshApp handles SSH configuration files
+type SshApp struct {
+	BaseApp
+}
+
+func NewSshApp() DotfileApp {
+	return &SshApp{}
+}
+
+func (s *SshApp) Name() string {
+	return "ssh"
+}
+
+func (s *SshApp) GetConfigPaths() []string {
+	return []string{
+		"~/.ssh/config",
+	}
+}
+
+func (s *SshApp) CollectDotfiles(ctx context.Context) ([]DotfileItem, error) {
+	return s.CollectFromPaths(ctx, s.Name(), s.GetConfigPaths())
+}


### PR DESCRIPTION
Adds support for 4 new dotfile applications: npm, ssh, kitty, and kubernetes.

## Changes
- Add NpmApp implementation for `~/.npmrc` configuration
- Add SshApp implementation for `~/.ssh/config` configuration
- Add KittyApp implementation for `~/.config/kitty/` directory
- Add KubernetesApp implementation for `~/.kube/config` configuration
- Update dotfiles_pull.go to include all new apps in available handlers
- Update dotfiles_push.go to include all new apps in available handlers

## Usage

```bash
# Push specific configs to server
shelltime dotfiles push --apps npm,ssh,kitty,kubernetes

# Pull specific configs from server
shelltime dotfiles pull --apps npm,ssh,kitty,kubernetes
```

Fixes #87

🤖 Generated with [Claude Code](https://claude.ai/code)