### PR TITLE
feat(dotfile): add support for ignoring sections in collected files

### DIFF
--- a/model/dotfile_bash.go
+++ b/model/dotfile_bash.go
@@ -25,5 +25,6 @@ func (b *BashApp) GetConfigPaths() []string {
 }
 
 func (b *BashApp) CollectDotfiles(ctx context.Context) ([]DotfileItem, error) {
-	return b.CollectFromPaths(ctx, b.Name(), b.GetConfigPaths())
+	skipIgnored := true
+	return b.CollectFromPaths(ctx, b.Name(), b.GetConfigPaths(), &skipIgnored)
 }

--- a/model/dotfile_claude.go
+++ b/model/dotfile_claude.go
@@ -23,5 +23,6 @@ func (c *ClaudeApp) GetConfigPaths() []string {
 }
 
 func (c *ClaudeApp) CollectDotfiles(ctx context.Context) ([]DotfileItem, error) {
-	return c.CollectFromPaths(ctx, c.Name(), c.GetConfigPaths())
+	skipIgnored := true
+	return c.CollectFromPaths(ctx, c.Name(), c.GetConfigPaths(), &skipIgnored)
 }

--- a/model/dotfile_fish.go
+++ b/model/dotfile_fish.go
@@ -24,5 +24,6 @@ func (f *FishApp) GetConfigPaths() []string {
 }
 
 func (f *FishApp) CollectDotfiles(ctx context.Context) ([]DotfileItem, error) {
-	return f.CollectFromPaths(ctx, f.Name(), f.GetConfigPaths())
+	skipIgnored := true
+	return f.CollectFromPaths(ctx, f.Name(), f.GetConfigPaths(), &skipIgnored)
 }

--- a/model/dotfile_ghostty.go
+++ b/model/dotfile_ghostty.go
@@ -23,5 +23,6 @@ func (g *GhosttyApp) GetConfigPaths() []string {
 }
 
 func (g *GhosttyApp) CollectDotfiles(ctx context.Context) ([]DotfileItem, error) {
-	return g.CollectFromPaths(ctx, g.Name(), g.GetConfigPaths())
+	skipIgnored := true
+	return g.CollectFromPaths(ctx, g.Name(), g.GetConfigPaths(), &skipIgnored)
 }

--- a/model/dotfile_git.go
+++ b/model/dotfile_git.go
@@ -25,5 +25,6 @@ func (g *GitApp) GetConfigPaths() []string {
 }
 
 func (g *GitApp) CollectDotfiles(ctx context.Context) ([]DotfileItem, error) {
-	return g.CollectFromPaths(ctx, g.Name(), g.GetConfigPaths())
+	skipIgnored := true
+	return g.CollectFromPaths(ctx, g.Name(), g.GetConfigPaths(), &skipIgnored)
 }

--- a/model/dotfile_kitty.go
+++ b/model/dotfile_kitty.go
@@ -22,5 +22,6 @@ func (k *KittyApp) GetConfigPaths() []string {
 }
 
 func (k *KittyApp) CollectDotfiles(ctx context.Context) ([]DotfileItem, error) {
-	return k.CollectFromPaths(ctx, k.Name(), k.GetConfigPaths())
+	skipIgnored := true
+	return k.CollectFromPaths(ctx, k.Name(), k.GetConfigPaths(), &skipIgnored)
 }

--- a/model/dotfile_kubernetes.go
+++ b/model/dotfile_kubernetes.go
@@ -22,5 +22,6 @@ func (k *KubernetesApp) GetConfigPaths() []string {
 }
 
 func (k *KubernetesApp) CollectDotfiles(ctx context.Context) ([]DotfileItem, error) {
-	return k.CollectFromPaths(ctx, k.Name(), k.GetConfigPaths())
+	skipIgnored := true
+	return k.CollectFromPaths(ctx, k.Name(), k.GetConfigPaths(), &skipIgnored)
 }

--- a/model/dotfile_npm.go
+++ b/model/dotfile_npm.go
@@ -22,5 +22,6 @@ func (n *NpmApp) GetConfigPaths() []string {
 }
 
 func (n *NpmApp) CollectDotfiles(ctx context.Context) ([]DotfileItem, error) {
-	return n.CollectFromPaths(ctx, n.Name(), n.GetConfigPaths())
+	skipIgnored := true
+	return n.CollectFromPaths(ctx, n.Name(), n.GetConfigPaths(), &skipIgnored)
 }

--- a/model/dotfile_nvim.go
+++ b/model/dotfile_nvim.go
@@ -23,5 +23,6 @@ func (n *NvimApp) GetConfigPaths() []string {
 }
 
 func (n *NvimApp) CollectDotfiles(ctx context.Context) ([]DotfileItem, error) {
-	return n.CollectFromPaths(ctx, n.Name(), n.GetConfigPaths())
+	skipIgnored := true
+	return n.CollectFromPaths(ctx, n.Name(), n.GetConfigPaths(), &skipIgnored)
 }

--- a/model/dotfile_ssh.go
+++ b/model/dotfile_ssh.go
@@ -22,5 +22,6 @@ func (s *SshApp) GetConfigPaths() []string {
 }
 
 func (s *SshApp) CollectDotfiles(ctx context.Context) ([]DotfileItem, error) {
-	return s.CollectFromPaths(ctx, s.Name(), s.GetConfigPaths())
+	skipIgnored := true
+	return s.CollectFromPaths(ctx, s.Name(), s.GetConfigPaths(), &skipIgnored)
 }

--- a/model/dotfile_starship.go
+++ b/model/dotfile_starship.go
@@ -22,5 +22,6 @@ func (s *StarshipApp) GetConfigPaths() []string {
 }
 
 func (s *StarshipApp) CollectDotfiles(ctx context.Context) ([]DotfileItem, error) {
-	return s.CollectFromPaths(ctx, s.Name(), s.GetConfigPaths())
+	skipIgnored := true
+	return s.CollectFromPaths(ctx, s.Name(), s.GetConfigPaths(), &skipIgnored)
 }

--- a/model/dotfile_zsh.go
+++ b/model/dotfile_zsh.go
@@ -25,5 +25,6 @@ func (z *ZshApp) GetConfigPaths() []string {
 }
 
 func (z *ZshApp) CollectDotfiles(ctx context.Context) ([]DotfileItem, error) {
-	return z.CollectFromPaths(ctx, z.Name(), z.GetConfigPaths())
+	skipIgnored := true
+	return z.CollectFromPaths(ctx, z.Name(), z.GetConfigPaths(), &skipIgnored)
 }


### PR DESCRIPTION
## Summary
- Add optional boolean parameter to `CollectFromPaths` to skip content between ignore markers
- Implement `filterIgnoredSections` function to remove lines between `SHELLTIME IGNORE BEGIN` and `SHELLTIME IGNORE END`
- Update all dotfile app implementations to use the new parameter with default value `true`

## Changes
- Modified `BaseApp.CollectFromPaths` to accept optional `skipIgnoredSections` parameter (defaults to `true`)
- Added `filterIgnoredSections` method to filter out sensitive content
- Updated all 13 dotfile app implementations to pass `true` for the new parameter
- Added comprehensive tests for the ignore functionality

## Test Plan
- [x] Added test case for ignored sections functionality
- [x] Updated existing tests to pass the new parameter
- [x] Verified filtering works correctly with both `skipIgnored=true` and `skipIgnored=false`

Fixes #102

🤖 Generated with [Claude Code](https://claude.ai/code)