### PR TITLE
fix(model): implement custom lookPath for node package managers

### DIFF
--- a/model/ccusage_service.go
+++ b/model/ccusage_service.go
@@ -283,8 +283,9 @@ func lookPath(name string) (string, error) {
 	for _, path := range searchPaths {
 		// Handle glob patterns (like nvm versions)
 		if matches, err := filepath.Glob(path); err == nil && len(matches) > 0 {
-			// Use the first match
-			path = matches[0]
+			// Use the last match, which is likely to be the latest version
+			// since Glob returns a sorted list.
+			path = matches[len(matches)-1]
 		}
 
 		// Check if the file exists and is executable

--- a/model/ccusage_service.go
+++ b/model/ccusage_service.go
@@ -254,12 +254,12 @@ func lookPath(name string) (string, error) {
 			filepath.Join(homeDir, ".local", "share", "fnm", "node-versions", "*", "installation", "bin", name),
 			filepath.Join(homeDir, ".fnm", "node-versions", "*", "installation", "bin", name),
 			// Homebrew on macOS (Intel)
-			"/usr/local/bin/" + name,
+			filepath.Join("/usr/local/bin", name),
 			// Homebrew on macOS (Apple Silicon)
-			"/opt/homebrew/bin/" + name,
+			filepath.Join("/opt/homebrew/bin", name),
 			// Common system paths
-			"/usr/bin/" + name,
-			"/bin/" + name,
+			filepath.Join("/usr/bin", name),
+			filepath.Join("/bin", name),
 		}
 
 		// Add Node.js versions from nvm if NVM_DIR is set

--- a/model/ccusage_service.go
+++ b/model/ccusage_service.go
@@ -250,6 +250,9 @@ func lookPath(name string) (string, error) {
 			filepath.Join(homeDir, ".bun", "bin", name),
 			// NVM (Node Version Manager) current version
 			filepath.Join(homeDir, ".nvm", "current", "bin", name),
+			// fnm (Fast Node Manager) installations
+			filepath.Join(homeDir, ".local", "share", "fnm", "node-versions", "*", "installation", "bin", name),
+			filepath.Join(homeDir, ".fnm", "node-versions", "*", "installation", "bin", name),
 			// Homebrew on macOS (Intel)
 			"/usr/local/bin/" + name,
 			// Homebrew on macOS (Apple Silicon)
@@ -265,6 +268,13 @@ func lookPath(name string) (string, error) {
 			searchPaths = append(searchPaths,
 				filepath.Join(nvmDir, "current", "bin", name),
 				filepath.Join(nvmDir, "versions", "node", "*", "bin", name),
+			)
+		}
+
+		// Add Node.js versions from fnm if FNM_DIR is set
+		if fnmDir := os.Getenv("FNM_DIR"); fnmDir != "" {
+			searchPaths = append(searchPaths,
+				filepath.Join(fnmDir, "node-versions", "*", "installation", "bin", name),
 			)
 		}
 	}

--- a/model/ccusage_service.go
+++ b/model/ccusage_service.go
@@ -313,7 +313,7 @@ func (s *ccUsageService) collectData(ctx context.Context, since time.Time) (*CCU
 	npxPath, npxErr := lookPath("npx")
 
 	if bunxErr != nil && npxErr != nil {
-		return nil, fmt.Errorf("neither bunx nor npx found in system PATH")
+		return nil, fmt.Errorf("neither bunx nor npx found in system PATH or common installation locations")
 	}
 
 	// Build command arguments


### PR DESCRIPTION
Replace exec.LookPath with a custom lookPath function that checks common installation locations for bunx and npx executables. This fixes the issue where the daemon service cannot find these executables because the PATH environment variable doesn't include user-specific Node.js installation paths.

Fixes #112

---
Generated with [Claude Code](https://claude.ai/code)