### PR TITLE
refactor(encoding): replace msgpack with JSON encoding

### DIFF
--- a/daemon/handlers.sync.go
+++ b/daemon/handlers.sync.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"time"
 
@@ -74,7 +75,7 @@ func handlePubSubSync(ctx context.Context, socketMsgPayload interface{}) error {
 				slog.Error("Failed to encrypt key", slog.Any("err", err))
 			}
 
-			buf, err := msgpack.Marshal(payload)
+			buf, err := json.Marshal(payload)
 
 			if err != nil {
 				slog.Error("Failed to marshal payload", slog.Any("err", err))

--- a/model/handshake.go
+++ b/model/handshake.go
@@ -50,7 +50,7 @@ func (hs handshakeService) send(ctx context.Context, path string, jsonData []byt
 		return
 	}
 
-	req.Header.Set("Content-Type", "application/msgpack")
+	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", fmt.Sprintf("shelltimeCLI@%s", commitID))
 	resp, err := hc.Do(req)
 	if err != nil {

--- a/model/handshake.go
+++ b/model/handshake.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"github.com/vmihailenco/msgpack/v5"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
@@ -103,7 +102,7 @@ func (hs handshakeService) Init(ctx context.Context) (string, error) {
 		OSVersion: sysInfo.Version,
 	}
 
-	jsonData, err := msgpack.Marshal(data)
+	jsonData, err := json.Marshal(data)
 	if err != nil {
 		logrus.Errorln(err)
 		return "", err
@@ -130,7 +129,7 @@ func (hs handshakeService) Check(ctx context.Context, handshakeId string) (token
 		EncodedID: handshakeId,
 	}
 
-	jsonData, err := msgpack.Marshal(data)
+	jsonData, err := json.Marshal(data)
 	if err != nil {
 		logrus.Errorln(err)
 		return "", err

--- a/model/handshake_test.go
+++ b/model/handshake_test.go
@@ -2,13 +2,13 @@ package model
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/vmihailenco/msgpack/v5"
 )
 
 type handshakeTestSuite struct {
@@ -21,12 +21,12 @@ func (s *handshakeTestSuite) TestHandshakeInitSuccess() {
 		// Verify request
 		assert.Equal(t, "POST", r.Method)
 		assert.Equal(t, "/api/v1/handshake/init", r.URL.Path)
-		assert.Equal(t, "application/msgpack", r.Header.Get("Content-Type"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 		assert.Contains(t, r.Header.Get("User-Agent"), "shelltimeCLI@")
 
 		// Decode request body
 		var payload handshakeInitRequest
-		err := msgpack.NewDecoder(r.Body).Decode(&payload)
+		err := json.NewDecoder(r.Body).Decode(&payload)
 		assert.NoError(t, err)
 
 		// Verify payload
@@ -74,11 +74,11 @@ func (s *handshakeTestSuite) TestHandshakeCheckWithToken() {
 		// Verify request
 		assert.Equal(t, "POST", r.Method)
 		assert.Equal(t, "/api/v1/handshake/check", r.URL.Path)
-		assert.Equal(t, "application/msgpack", r.Header.Get("Content-Type"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 
 		// Decode request body
 		var payload handshakeCheckRequest
-		err := msgpack.NewDecoder(r.Body).Decode(&payload)
+		err := json.NewDecoder(r.Body).Decode(&payload)
 		assert.NoError(t, err)
 
 		// Verify payload


### PR DESCRIPTION
## Summary
- Replaced msgpack encoding with standard JSON encoding across the codebase
- Updated daemon sync handler to use JSON marshaling
- Modified handshake service to use JSON instead of msgpack

## Rationale
This change simplifies the serialization format by using standard JSON encoding instead of msgpack. JSON is more widely supported and easier to debug, while still providing adequate performance for our use case.

## Changes
- `daemon/handlers.sync.go`: Switch from msgpack.Marshal to json.Marshal
- `model/handshake.go`: Replace msgpack with JSON in Init and Check methods
- `model/handshake_test.go`: Update tests to reflect JSON encoding

## Test plan
- [ ] Verify daemon sync functionality works correctly with JSON encoding
- [ ] Test handshake initialization and check operations
- [ ] Run existing test suite to ensure no regressions
- [ ] Validate backward compatibility if needed

🤖 Generated with Claude Code (https://claude.com/claude-code)