### PR TITLE
feat(daemon): support user-scope systemd service installation on Linux

### DIFF
--- a/model/sys-desc/shelltime.service
+++ b/model/sys-desc/shelltime.service
@@ -6,8 +6,6 @@ After=network.target
 Type=simple
 ExecStart=/usr/local/bin/shelltime-daemon
 Restart=always
-User=root
-Group=root
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
Changed Linux daemon installation from system-wide (root) to user-scope to match the Darwin implementation pattern and eliminate root permission requirements.

Closes #116

🤖 Generated with [Claude Code](https://claude.ai/code)