### PR TITLE
feat(daemon): update service descriptors for systemd and launchctl

### DIFF
--- a/model/sys-desc/shelltime.service
+++ b/model/sys-desc/shelltime.service
@@ -4,8 +4,15 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/shelltime-daemon
+ExecStart=/bin/sh -c 'exec $(getent passwd username | cut -d: -f7) -l -c "/usr/local/bin/shelltime-daemon"'
 Restart=always
+
+# Resource limits
+LimitNOFILE=65536
+
+# Logging
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=default.target

--- a/model/sys-desc/xyz.shelltime.daemon.plist
+++ b/model/sys-desc/xyz.shelltime.daemon.plist
@@ -6,7 +6,9 @@
     <string>xyz.shelltime.daemon</string>
     <key>ProgramArguments</key>
     <array>
-        <string>{{.BaseFolder}}/bin/shelltime-daemon</string>
+        <string>/bin/sh</string>
+        <string>-c</string>
+        <string>exec $SHELL -l -c '{{.BaseFolder}}/bin/shelltime-daemon'</string>
     </array>
     <key>RunAtLoad</key>
     <true/>


### PR DESCRIPTION
## Summary
- Updated systemd service file configuration
- Updated macOS launchctl plist configuration

## Changes
- `model/sys-desc/shelltime.service` - systemd service descriptor
- `model/sys-desc/xyz.shelltime.daemon.plist` - macOS launchctl daemon plist

## Test plan
- [ ] Verify systemd service starts correctly on Linux
- [ ] Verify launchctl daemon starts correctly on macOS
- [ ] Ensure daemon runs with correct permissions and paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)