### PR TITLE
fix(daemon): replace hardcoded username with $USER in systemd service

### DIFF
--- a/model/sys-desc/shelltime.service
+++ b/model/sys-desc/shelltime.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/bin/sh -c 'exec $(getent passwd username | cut -d: -f7) -l -c "/usr/local/bin/shelltime-daemon"'
+ExecStart=/bin/sh -c 'exec $(getent passwd $USER | cut -d: -f7) -l -c "/usr/local/bin/shelltime-daemon"'
 Restart=always
 
 # Resource limits


### PR DESCRIPTION
Fixes #132

Updated the systemd service file to use `$USER` instead of hardcoded `username` in the ExecStart command. This allows the service to dynamically resolve the current user's shell.

Generated with [Claude Code](https://claude.ai/code)