### PR TITLE
fix(daemon): use gui domain instead of deprecated user domain for launchctl

### DIFF
--- a/model/daemon-installer.darwin.go
+++ b/model/daemon-installer.darwin.go
@@ -32,7 +32,7 @@ func NewMacDaemonInstaller(baseFolder, user string) *MacDaemonInstaller {
 }
 
 func (m *MacDaemonInstaller) Check() error {
-	cmd := exec.Command("launchctl", "print", "user/"+fmt.Sprintf("%d", os.Getuid())+"/"+m.serviceName)
+	cmd := exec.Command("launchctl", "print", "gui/"+fmt.Sprintf("%d", os.Getuid())+"/"+m.serviceName)
 	if err := cmd.Run(); err == nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary
- Fixed daemon status check on macOS to use `gui` domain instead of deprecated `user` domain
- Changed from `user/501` to `gui/501` when running `launchctl print` command

## Problem
The `launchctl print user/501/xyz.shelltime.daemon` command was failing to find the running daemon service, even though the process was visible in Activity Monitor. This is because the `user` domain is deprecated in modern macOS versions.

## Solution
LaunchAgents in `~/Library/LaunchAgents/` run in the `gui` domain by default, not the `user` domain. Updated the Check() method in daemon-installer.darwin.go to use the correct domain.

## Test plan
- [ ] Install daemon on macOS: `shelltime daemon install`
- [ ] Verify daemon status check works: `shelltime daemon status`
- [ ] Confirm `launchctl print gui/501/xyz.shelltime.daemon` returns service info

🤖 Generated with [Claude Code](https://claude.com/claude-code)