### PR TITLE
feat(ai): add configurable tips display via showTips config

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ ShellTime CLI configuration is stored in `$HOME/.shelltime/config.toml`. The con
 | `ai.agent.view` | boolean | `false` | Allow AI to auto-execute read-only commands |
 | `ai.agent.edit` | boolean | `false` | Allow AI to auto-execute file editing commands |
 | `ai.agent.delete` | boolean | `false` | Allow AI to auto-execute deletion commands |
+| `ai.showTips` | boolean | `true` | Show AI-related tips and suggestions |
 
 #### Analytics Settings
 
@@ -99,6 +100,9 @@ exclude = [
 
 # AI configuration (optional)
 # Controls which command types the AI assistant can automatically execute
+[ai]
+showTips = true # Show AI-related tips and suggestions (default: true)
+
 [ai.agent]
 view = false    # Allow AI to execute read-only commands (ls, cat, less, head, tail, etc.)
 edit = false    # Allow AI to execute file editing commands (vim, nano, code, sed, etc.)

--- a/commands/query.go
+++ b/commands/query.go
@@ -123,7 +123,7 @@ func commandQuery(c *cli.Context) error {
 		} else {
 			// Display command with info about why it's not auto-running
 			displayCommand(newCommand)
-			if actionType != model.ActionOther {
+			if shouldShowTips(cfg) && actionType != model.ActionOther {
 				color.Yellow.Printf("\n💡 Tip: This is a %s command. Enable 'ai.agent.%s' in your config to auto-run it.\n",
 					actionType, actionType)
 			}
@@ -131,11 +131,13 @@ func commandQuery(c *cli.Context) error {
 	} else {
 		// No auto-run configured, display the command and tip
 		displayCommand(newCommand)
-		color.Yellow.Printf("\n💡 Tip: You can enable AI auto-run in your config file:\n")
-		color.Yellow.Printf("   [ai.agent]\n")
-		color.Yellow.Printf("   view = true    # Auto-run view commands\n")
-		color.Yellow.Printf("   edit = true    # Auto-run edit commands\n")
-		color.Yellow.Printf("   delete = true  # Auto-run delete commands\n")
+		if shouldShowTips(cfg) {
+			color.Yellow.Printf("\n💡 Tip: You can enable AI auto-run in your config file:\n")
+			color.Yellow.Printf("   [ai.agent]\n")
+			color.Yellow.Printf("   view = true    # Auto-run view commands\n")
+			color.Yellow.Printf("   edit = true    # Auto-run edit commands\n")
+			color.Yellow.Printf("   delete = true  # Auto-run delete commands\n")
+		}
 	}
 
 	return nil
@@ -144,6 +146,14 @@ func commandQuery(c *cli.Context) error {
 func displayCommand(command string) {
 	color.Green.Printf("💡 Suggested command:\n")
 	color.Cyan.Printf("%s\n", command)
+}
+
+func shouldShowTips(cfg model.ShellTimeConfig) bool {
+	// If ShowTips is not set (nil), default to true
+	if cfg.AI == nil || cfg.AI.ShowTips == nil {
+		return true
+	}
+	return *cfg.AI.ShowTips
 }
 
 func executeCommand(ctx context.Context, command string) error {

--- a/model/types.go
+++ b/model/types.go
@@ -13,7 +13,8 @@ type AIAgentConfig struct {
 }
 
 type AIConfig struct {
-	Agent AIAgentConfig `toml:"agent"`
+	Agent    AIAgentConfig `toml:"agent"`
+	ShowTips *bool         `toml:"showTips"`
 }
 
 type CCUsage struct {
@@ -62,6 +63,7 @@ var DefaultAIConfig = &AIConfig{
 		Edit:   false,
 		Delete: false,
 	},
+	ShowTips: nil, // defaults to true if nil
 }
 
 var DefaultConfig = ShellTimeConfig{


### PR DESCRIPTION
## Summary
- Added `showTips` configuration option under the `ai` config section
- Users can now disable AI-related tips by setting `ai.showTips = false` in their config
- Tips are shown by default (when not configured) to maintain backward compatibility
- The `shouldShowTips()` helper function checks this configuration before displaying tips

## Test plan
- [ ] Verify tips are shown by default when `showTips` is not configured
- [ ] Verify tips are hidden when `showTips = false` is set in config
- [ ] Verify tips are shown when `showTips = true` is explicitly set in config
- [ ] Test with AI auto-run enabled and disabled scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)